### PR TITLE
Add Connection String Regex to config/regexes.json

### DIFF
--- a/config/regexes.json
+++ b/config/regexes.json
@@ -12,6 +12,7 @@
     {"Basic_Auth":"Authorization:[[:space:]]Basic[[:space:]](?:[a-zA-Z0-9\\+/]{4})*(?:[a-zA-Z0-9\\+/]{3}=|[a-zA-Z0-9\\+/]{2}==)?(?:$|[[:space:];'\"'\"'\"])"},
     {".npmrc_auth":"(?i)^\\+[[:space:]]*\\_auth[[:space:]]*="},
     {".npmrc_password":"^\\+[[:space:]]*\\_password[[:space:]]*="},
+    {"Connection_String":"[0-9a-z-]{1,30}+:[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
     {"Secret_Generic_with_space_line_end":" secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:]]*$"},
     {"Secret_Generic_with_space_full_quotes":"secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:];'\"'\"'\"]+"},
     {"Secret_Generic_no_space_line_end":"secret['\"'\"'\"]?[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,45}[[:space:]]*$"},

--- a/config/regexes.json
+++ b/config/regexes.json
@@ -12,7 +12,7 @@
     {"Basic_Auth":"Authorization:[[:space:]]Basic[[:space:]](?:[a-zA-Z0-9\\+/]{4})*(?:[a-zA-Z0-9\\+/]{3}=|[a-zA-Z0-9\\+/]{2}==)?(?:$|[[:space:];'\"'\"'\"])"},
     {".npmrc_auth":"(?i)^\\+[[:space:]]*\\_auth[[:space:]]*="},
     {".npmrc_password":"^\\+[[:space:]]*\\_password[[:space:]]*="},
-    {"Connection_String":"[0-9a-z-]{3,30}(?<!mailto):[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
+    {"Connection_String":"[0-9a-z-]{3,30}(?<!(mailto)|(sip)):[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
     {"Secret_Generic_with_space_line_end":" secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:]]*$"},
     {"Secret_Generic_with_space_full_quotes":"secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:];'\"'\"'\"]+"},
     {"Secret_Generic_no_space_line_end":"secret['\"'\"'\"]?[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,45}[[:space:]]*$"},

--- a/config/regexes.json
+++ b/config/regexes.json
@@ -12,7 +12,7 @@
     {"Basic_Auth":"Authorization:[[:space:]]Basic[[:space:]](?:[a-zA-Z0-9\\+/]{4})*(?:[a-zA-Z0-9\\+/]{3}=|[a-zA-Z0-9\\+/]{2}==)?(?:$|[[:space:];'\"'\"'\"])"},
     {".npmrc_auth":"(?i)^\\+[[:space:]]*\\_auth[[:space:]]*="},
     {".npmrc_password":"^\\+[[:space:]]*\\_password[[:space:]]*="},
-    {"Connection_String":"[0-9a-z-]{1,30}+:[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
+    {"Connection_String":"[0-9a-z-]{1,30}(?<!mailto):[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
     {"Secret_Generic_with_space_line_end":" secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:]]*$"},
     {"Secret_Generic_with_space_full_quotes":"secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:];'\"'\"'\"]+"},
     {"Secret_Generic_no_space_line_end":"secret['\"'\"'\"]?[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,45}[[:space:]]*$"},

--- a/config/regexes.json
+++ b/config/regexes.json
@@ -12,7 +12,7 @@
     {"Basic_Auth":"Authorization:[[:space:]]Basic[[:space:]](?:[a-zA-Z0-9\\+/]{4})*(?:[a-zA-Z0-9\\+/]{3}=|[a-zA-Z0-9\\+/]{2}==)?(?:$|[[:space:];'\"'\"'\"])"},
     {".npmrc_auth":"(?i)^\\+[[:space:]]*\\_auth[[:space:]]*="},
     {".npmrc_password":"^\\+[[:space:]]*\\_password[[:space:]]*="},
-    {"Connection_String":"[0-9a-z-]{1,30}(?<!mailto):[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
+    {"Connection_String":"[0-9a-z-]{3,30}(?<!mailto):[0-9a-z%$_.+!*'(),-]+@[0-9a-z-.]{1,50}"},
     {"Secret_Generic_with_space_line_end":" secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:]]*$"},
     {"Secret_Generic_with_space_full_quotes":"secret[[:space:]]+[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,}[[:space:];'\"'\"'\"]+"},
     {"Secret_Generic_no_space_line_end":"secret['\"'\"'\"]?[=:]{1,2}[[:space:]]*['\"'\"'\"]?[[:alnum:]-]{8,45}[[:space:]]*$"},

--- a/testing/regex_testing/test_cases.txt
+++ b/testing/regex_testing/test_cases.txt
@@ -492,3 +492,6 @@
 +USER:${PASS_ENV}@abcwhatever>>pass
 +user:${password_env}@abcWhatever >>pass
 + System.getEnv("USER") + ":" + System.getEnv("PASS") + "@abc.mysite.com">>pass
++mailto:name@mydomain.com>>pass
++ mailto:name@mydomain.com >>pass
++<a href="mailto:name@mydomain.com">Click Here To Email Me</a> >>pass

--- a/testing/regex_testing/test_cases.txt
+++ b/testing/regex_testing/test_cases.txt
@@ -495,3 +495,5 @@
 +mailto:name@mydomain.com>>pass
 + mailto:name@mydomain.com >>pass
 +<a href="mailto:name@mydomain.com">Click Here To Email Me</a> >>pass
++for (i in 1:length(grid@my_ids)){>>pass
++  for (i in 10:length(grid@my_ids)){ >>pass

--- a/testing/regex_testing/test_cases.txt
+++ b/testing/regex_testing/test_cases.txt
@@ -497,3 +497,7 @@
 +<a href="mailto:name@mydomain.com">Click Here To Email Me</a> >>pass
 +for (i in 1:length(grid@my_ids)){>>pass
 +  for (i in 10:length(grid@my_ids)){ >>pass
++sip:name@mydomain.com>>pass
++ sip:name@mydomain.com >>pass
++'sip:name@domain.com','sip:othername@domain.com',>>pass
++'sip:name@domain.com','sip:othername@domain.com' >>pass

--- a/testing/regex_testing/test_cases.txt
+++ b/testing/regex_testing/test_cases.txt
@@ -476,3 +476,19 @@
 +thisismyNOTsecret123appkey>>pass
 +thisisNOTmysecret123applicationkey>>pass
 +thisisNOTmysecret123Applicationkey>>pass
++ 'database': 'mongodb://EVILUSER:A1bcdEf@Abc12345.mysite.com:27010,Abc12345.mysite.com:27010/LUSER?set=PROD'>>fail
++ "ConnectionString": "mongodb://ABCDUSER:1abCDEfg@Abc1234.mysite.com:27010,Abc1234.mysite.com:27010/AUSER?set=PROD",>>fail
++ 'ssh': 'ssh://EVILUSER:A1bcdEf@Abc12345.mysite.com:22>>fail
++ 'ssh': 'ssh://EVILUSER:p.a+-w0(rD1!@Abc12345.mysite.com:22 >>fail
++ 'ftp': 'ftp://eviluser:p%40%24%24w0rD1%21@Abc12345.mysite.com:22>>fail
++ 'credentials': 'eviluser:A1bcdEf@Abc12345'>>fail
++ "credentials": "evilUser:A1bcdEf@Abc12345">>fail
++ 'credentials': 'eviluser:A1bcdEf@Abc12345' >>fail
++ 'credentials': 'Eviluser:pa$$\1_.+!*'%(worD),-@Abc12345' >>fail
++credential=eviluser:A1bcdEf@Abc12345>>fail
++credential=eviluser:A1bcdEf@Abc12345 >>fail
++ 'database': 'mongodb://${USER_ENV}:${PASS_ENV}@Abc12345.mysite.com:27010,Abc12345.mysite.com:27010/LUSER?set=PROD'>>pass
++${USER_ENV}:${PASS_ENV}@abcwhatever.mysite.com>>pass
++USER:${PASS_ENV}@abcwhatever>>pass
++user:${password_env}@abcWhatever >>pass
++ System.getEnv("USER") + ":" + System.getEnv("PASS") + "@abc.mysite.com">>pass


### PR DESCRIPTION
Added new regex to flag connection strings that contain hard-coded credentials/sensitive data such as `user:password@server` while still not flagging `mailto` or `sip` addresses.